### PR TITLE
Create zh_CN.lang

### DIFF
--- a/src/main/resources/assets/flamingo/lang/zh_CN.lang
+++ b/src/main/resources/assets/flamingo/lang/zh_CN.lang
@@ -1,0 +1,1 @@
+tile.flamingo.flamingo.name=粉红色火烈鸟


### PR DESCRIPTION
In fact, before this pull request, I tested Google Translate with "pink flamingo" and it gave back the correct Chinese translation.
Also this one can be used in 1.7.10, 'cause both lang files are entirely identical. 