### PR TITLE
Wobble on right click too

### DIFF
--- a/src/main/java/com/reddit/user/koppeh/flamingo/FlamingoBlock.java
+++ b/src/main/java/com/reddit/user/koppeh/flamingo/FlamingoBlock.java
@@ -56,21 +56,10 @@ public class FlamingoBlock extends Block implements BlockEntityProvider, BlockAt
 
 	@Override
 	public boolean onAttackInteraction(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, Direction direction) {
-		onClick(world, pos);
-		return false;
-	}
-
-	@Override
-	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
-		onClick(world, pos);
-		return ActionResult.SUCCESS;
-	}
-
-	private void onClick(World world, BlockPos pos)
-	{
 		if (!world.isClient && world.getBlockEntity(pos) instanceof FlamingoBlockEntity) {
 			world.addSyncedBlockEvent(pos, this, 0, 0);
 		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/com/reddit/user/koppeh/flamingo/FlamingoBlock.java
+++ b/src/main/java/com/reddit/user/koppeh/flamingo/FlamingoBlock.java
@@ -10,7 +10,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.IntProperty;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
@@ -54,11 +56,21 @@ public class FlamingoBlock extends Block implements BlockEntityProvider, BlockAt
 
 	@Override
 	public boolean onAttackInteraction(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, Direction direction) {
-		BlockEntity blockEntity = world.getBlockEntity(pos);
-		if (!world.isClient && blockEntity instanceof FlamingoBlockEntity) {
+		onClick(world, pos);
+		return false;
+	}
+
+	@Override
+	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+		onClick(world, pos);
+		return ActionResult.SUCCESS;
+	}
+
+	private void onClick(World world, BlockPos pos)
+	{
+		if (!world.isClient && world.getBlockEntity(pos) instanceof FlamingoBlockEntity) {
 			world.addSyncedBlockEvent(pos, this, 0, 0);
 		}
-		return false;
 	}
 
 	@Override

--- a/src/main/java/com/reddit/user/koppeh/flamingo/mixin/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/com/reddit/user/koppeh/flamingo/mixin/MixinClientPlayerInteractionManager.java
@@ -1,0 +1,41 @@
+package com.reddit.user.koppeh.flamingo.mixin;
+
+import com.reddit.user.koppeh.flamingo.FlamingoBlock;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.GameMode;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerInteractionManager.class)
+public abstract class MixinClientPlayerInteractionManager {
+    @Shadow
+    @Final
+    private MinecraftClient client;
+
+    @Shadow
+    private GameMode gameMode;
+
+    @Shadow
+    protected abstract void sendPlayerAction(PlayerActionC2SPacket.Action action, BlockPos pos, Direction direction);
+
+    @Inject(at = @At("HEAD"), method = "attackBlock", cancellable = true)
+    public void attackBlock(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
+        if (gameMode != GameMode.ADVENTURE) return;
+
+        var block = client.world.getBlockState(pos);
+        if (!(block.getBlock() instanceof FlamingoBlock flamingo)) return;
+
+        flamingo.onAttackInteraction(block, client.world, pos, client.player, Hand.MAIN_HAND, direction);
+        sendPlayerAction(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, pos, direction);
+        info.setReturnValue(true);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,5 +25,8 @@
   "contributors": [
 	"Prospector"
   ],
-  "description": "Adds a decorative pink flamingo block. Suggested by and dedicated to Reddit. Inspired by Dig Build Live."
+  "description": "Adds a decorative pink flamingo block. Suggested by and dedicated to Reddit. Inspired by Dig Build Live.",
+  "mixins": [
+    "flamingo.mixins.json"
+  ]
 }

--- a/src/main/resources/flamingo.mixins.json
+++ b/src/main/resources/flamingo.mixins.json
@@ -1,0 +1,7 @@
+{
+  "package": "com.reddit.user.koppeh.flamingo.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+    "MixinClientPlayerInteractionManager"
+  ]
+}


### PR DESCRIPTION
When players are in adventure mode, they can't attack blocks. As a result, they can't wobble flamingos, massively limiting the experience!

While we could mixin to allow attacking blocks in adventure mode, it's a lot more complex to do and I'm not 100% comfortable that I'd get it right. While this change isn't 100% authentic Flamingo :tm:, I think it's a suitable compromise.